### PR TITLE
fix compilation issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.4.6"
+version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c909eb55443867ff73a36c7c28784f02496e657c9618cdfed0c70a8379b911a"
+checksum = "781d258743e6e07d38c5bcd7468cfaa068d56789d10e8de0d3836d5bb338b5d7"
 dependencies = [
  "libc",
  "winapi",

--- a/natpl-cli/Cargo.toml
+++ b/natpl-cli/Cargo.toml
@@ -14,5 +14,5 @@ directories = "4.0.1"
 natpl = { path = "../natpl" }
 natpl-repl = { path = "../natpl-repl" }
 owo-colors = "3.0.1"
-rustyline = "*"
+rustyline = "9.0.0"
 thiserror = "1.0"


### PR DESCRIPTION
- older GMP version throws C++ compilation errors on recent toolchains, updated
- pin rustyline major version so natpl compiles without a lockfile too